### PR TITLE
fix loading one-to-many relationship with no backref

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,3 +6,4 @@ answer newbie questions, and generally improved sqla_yaml_fixtures:
 
     Eduardo Naufel Schettino <http://schettino72.net>
     Just van den Broecke <http://www.justobjects.nl>
+    Tim Chen <timchen1@gmail.com>

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+0.8.0 (unreleased)
+======================
+
+- fix loading many relationships without backref
+
 0.7.0 (2017-09-01)
 ======================
 

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ def readme():
 
 setup(name='sqla_yaml_fixtures',
       description='Load YAML data fixtures for SQLAlchemy',
-      version='0.7.0',
+      version='0.8.0',
       license='MIT',
       author='Eduardo Naufel Schettino',
       author_email='schettino72@gmail.com',

--- a/sqla_yaml_fixtures/__init__.py
+++ b/sqla_yaml_fixtures/__init__.py
@@ -9,7 +9,7 @@ except ImportError:  # pragma: no cover
     # For Python 2
     from backports.functools_lru_cache import lru_cache
 
-__version__ = (0, 7, 0)
+__version__ = (0, 8, 0)
 
 
 class Store:

--- a/sqla_yaml_fixtures/__init__.py
+++ b/sqla_yaml_fixtures/__init__.py
@@ -127,9 +127,17 @@ def _create_obj(ModelBase, session, store,
 
                 # else they are a list of nested elements
                 else:
-                    nested.extend(
-                        [rel_name, column.back_populates, v]
-                        for v in value)
+                    if column.back_populates:
+                        nested.extend(
+                            [rel_name, column.back_populates, v]
+                            for v in value)
+                    # If there is no back_populates create the nested objects
+                    # first
+                    else:
+                        scalars[name] = [_create_obj(
+                            ModelBase, session, store,
+                            rel_name, None, None, v)
+                            for v in value]
 
             # nested field which object was just created
             else:

--- a/tests/test_sqla_yaml_fixtures.py
+++ b/tests/test_sqla_yaml_fixtures.py
@@ -19,6 +19,15 @@ class User(BaseModel):
     id = Column(Integer, primary_key=True)
     username = Column(String(150), nullable=False, unique=True)
     email = Column(String(254), unique=True)
+    roles = relationship('Role')
+
+
+class Role(BaseModel):
+    __tablename__ = 'role'
+    id = Column(Integer, primary_key=True)
+    name = Column(String(150), nullable=False)
+    user_id = Column(ForeignKey('user.id'), nullable=False)
+    user = relationship('User')
 
 
 class Profile(BaseModel):
@@ -347,6 +356,23 @@ def test_2many(session):
     assert len(groups) == 1
     assert groups[0].members[0].profile.name == 'Jeffrey'
     assert groups[0].members[0].profile.groups[0].group.name == 'Ramones'
+
+
+def test_2many_no_backref(session):
+    fixture = """
+- User:
+  - __key__: joey
+    username: joey
+    email: joey@example.com
+    roles:
+      - name: owner
+      - name: editor
+      - name: viewer
+"""
+    data = sqla_yaml_fixtures.load(BaseModel, session, fixture)
+    roles = session.query(Role).all()
+    assert len(roles) == 3
+    assert roles[0].user_id == data.get('joey').id
 
 
 def test_2many_invalid_ref(session):


### PR DESCRIPTION
Fix the case when a model has one-to-many relationship with no `backref`.  This is very similar to the previous block of code where you check for `column.back_populates` https://github.com/timc13/sqla_yaml_fixtures/blob/nested-collection-values/sqla_yaml_fixtures/__init__.py#L99-L110