### PR TITLE
feat(session): Use merge instead of add

### DIFF
--- a/sqla_yaml_fixtures/__init__.py
+++ b/sqla_yaml_fixtures/__init__.py
@@ -20,11 +20,11 @@ def from_registry(Base, model_name):
 
 
 class Store:
-    '''Simple key-value store
+    """Simple key-value store
 
     Key might be a dot-separated where each name after a dot
     represents and attribute of the value-object.
-    '''
+    """
 
     def __init__(self):
         self._store = {}
@@ -43,9 +43,9 @@ class Store:
 
 @lru_cache()
 def _get_rel_col_for(src_model, target_model_name):
-    '''find the column in src_model that is a relationship to target_model
+    """find the column in src_model that is a relationship to target_model
     @return column name
-    '''
+    """
     # FIXME deal with self-referential m2m
     for name, col in src_model._sa_class_manager.items():
         try:
@@ -60,7 +60,7 @@ def _get_rel_col_for(src_model, target_model_name):
 
 def _create_obj(ModelBase, session, store,
                 model_name, creator, key, values):
-    '''create obj from values
+    """create obj from values
 
     :var store (Store):
     :var model_name (str): name of Model/Mapper
@@ -68,7 +68,7 @@ def _create_obj(ModelBase, session, store,
                         Takes 2 parameters (session, values)
     :var key (str): key for obj in Store
     :var values (dict): column:value
-    '''
+    """
     # get reference to SqlAlchemy Mapper
     model = from_registry(ModelBase, model_name)
 
@@ -220,6 +220,6 @@ def load(ModelBase, session, fixture_text, loader=None):
             key = fields.pop('__key__', None)
             obj = _create_obj(ModelBase, session, store,
                               model_name, creator, key, fields)
-            session.add(obj)
+            session.merge(obj)
     session.commit()
     return store

--- a/sqla_yaml_fixtures/__init__.py
+++ b/sqla_yaml_fixtures/__init__.py
@@ -196,9 +196,9 @@ def load(ModelBase, session, fixture_text, loader=None):
     if not isinstance(data, list):
         raise ValueError('Top level YAML should be sequence (list).')
 
-    return load_dict(ModelBase, session, data)
+    return load_list(ModelBase, session, data)
 
-def load_dict(ModelBase, session, data: list) -> Store:
+def load_list(ModelBase, session, data: list) -> Store:
     # make sure backref attributes are created
     sqlalchemy.orm.configure_mappers()
 

--- a/sqla_yaml_fixtures/__init__.py
+++ b/sqla_yaml_fixtures/__init__.py
@@ -185,9 +185,6 @@ def _create_obj(ModelBase, session, store,
 
 
 def load(ModelBase, session, fixture_text, loader=None):
-    # make sure backref attributes are created
-    sqlalchemy.orm.configure_mappers()
-
     # Data should be sequence of entry per mapper name
     # to enforce that FKs (__key__ entries) are defined first
     if loader is None:
@@ -195,6 +192,12 @@ def load(ModelBase, session, fixture_text, loader=None):
     data = yaml.load(fixture_text, Loader=loader)
     if not isinstance(data, list):
         raise ValueError('Top level YAML should be sequence (list).')
+
+    return load_dict(ModelBase, session, data)
+
+def load_dict(ModelBase, session, data: list) -> Store:
+    # make sure backref attributes are created
+    sqlalchemy.orm.configure_mappers()
 
     store = Store()
     for model_entry in data:


### PR DESCRIPTION
This allows to update records by primary key,  should solve #6 
See `merge` docs https://docs.sqlalchemy.org/en/20/orm/session_api.html#sqlalchemy.orm.Session.merge

* Adds `load_list` function to allow loading fixtures from list type (this allows use of other parsers then yml
* Allows use of __key__ in nested objects:
```yml
- Form:
  - id: 'fdc76171-e06a-499d-9f33-42768b8481f1'
    name: 'Test'
    form_steps:
        - __key__: 'my_key'  # Works now!
          name: 'Step 1'
        - name: 'Step 2'
          parent_step: 'my_key'
```

